### PR TITLE
Cleaning up mqtt topics to be of a more readable and accepted by Home Assistant format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 
 # Config file which may contain secrets
 config.json
+/.vscode

--- a/RP2040Home/configparsing/__init__.py
+++ b/RP2040Home/configparsing/__init__.py
@@ -1,4 +1,0 @@
-from . import configparser
-from . import homeassistantdiscoveryconfig
-from . import mqttconfig
-from . import output

--- a/RP2040Home/configparsing/configparser.py
+++ b/RP2040Home/configparsing/configparser.py
@@ -32,15 +32,3 @@ class ConfigParser:
             except json.JSONDecodeError as exc:
                 print(exc)
         return self
-    
-    def clean_string(self, input_string:str):
-        return self.replace_white_space(self.replace_bad_characters(input_string))
-    
-    def replace_white_space(self, input_string:str):
-        return "-".join(input_string.split())
-    # Home Assistant doesn't really like anything that doesn't fit the [a-zA-Z0-9_-] pattern https://www.home-assistant.io/integrations/mqtt/#discovery-messages
-    def replace_bad_characters(self, input_string: str):
-        pattern = re.compile("[^a-zA-Z0-9_-]")
-        cleaned_text = pattern.sub('-', input_string)
-        
-        return cleaned_text

--- a/RP2040Home/configparsing/configparser.py
+++ b/RP2040Home/configparsing/configparser.py
@@ -1,7 +1,7 @@
 from .mqttconfig import MqttConfig
 from .output import Output
 from .wificonfig import WifiConfig
-import json
+import json, re
 
 class ConfigParser:
     wifi_config: list[WifiConfig]
@@ -32,3 +32,15 @@ class ConfigParser:
             except json.JSONDecodeError as exc:
                 print(exc)
         return self
+    
+    def clean_string(self, input_string:str):
+        return self.replace_white_space(self.replace_bad_characters(input_string))
+    
+    def replace_white_space(self, input_string:str):
+        return "-".join(input_string.split())
+    # Home Assistant doesn't really like anything that doesn't fit the [a-zA-Z0-9_-] pattern https://www.home-assistant.io/integrations/mqtt/#discovery-messages
+    def replace_bad_characters(self, input_string: str):
+        pattern = re.compile("[^a-zA-Z0-9_-]")
+        cleaned_text = pattern.sub('-', input_string)
+        
+        return cleaned_text

--- a/RP2040Home/configparsing/homeassistantdiscoveryconfig.py
+++ b/RP2040Home/configparsing/homeassistantdiscoveryconfig.py
@@ -1,9 +1,14 @@
-from RP2040Home.configparsing.configparser import ConfigParser
+from RP2040Home.configparsing.inputsanitisation import InputSanitisation
 
 class HomeAssistantDiscoveryConfig:
     enabled: str
     node_id: str
     
     def __init__(self, enabled:str, node_id: str):
-        self.enabled = ConfigParser.clean_string(enabled)
-        self.node_id = ConfigParser.clean_string(node_id)
+        self.enabled = InputSanitisation().clean_string(enabled)
+        self.node_id = InputSanitisation().clean_string(node_id)
+
+    def __eq__(self, other):
+        if not isinstance(other, HomeAssistantDiscoveryConfig):
+            return False
+        return self.__dict__ == other.__dict__

--- a/RP2040Home/configparsing/homeassistantdiscoveryconfig.py
+++ b/RP2040Home/configparsing/homeassistantdiscoveryconfig.py
@@ -1,7 +1,9 @@
+from RP2040Home.configparsing.configparser import ConfigParser
+
 class HomeAssistantDiscoveryConfig:
     enabled: str
     node_id: str
     
     def __init__(self, enabled:str, node_id: str):
-        self.enabled = enabled
-        self.node_id = node_id
+        self.enabled = ConfigParser.clean_string(enabled)
+        self.node_id = ConfigParser.clean_string(node_id)

--- a/RP2040Home/configparsing/inputsanitisation.py
+++ b/RP2040Home/configparsing/inputsanitisation.py
@@ -1,0 +1,18 @@
+import re
+
+class InputSanitisation:
+    
+    def clean_string(self, input_string:str):
+        return self.replace_white_space(self.replace_bad_characters(input_string))
+    
+    def replace_white_space(self, input_string:str):
+        return "-".join(input_string.split("-"))
+    # Home Assistant doesn't really like anything that doesn't fit the [a-zA-Z0-9_-] pattern https://www.home-assistant.io/integrations/mqtt/#discovery-messages
+    def replace_bad_characters(self, input_string: str):
+        invalid_character_pattern = re.compile("[^a-zA-Z0-9_-]")
+        cleaned_text = invalid_character_pattern.sub('-', input_string)
+        multiple_dash_pattern = re.compile("-+")
+        cleaned_text = multiple_dash_pattern.sub("-", cleaned_text)
+        trailing_dashes = re.compile("-*$|^-*")
+        cleaned_text = trailing_dashes.sub("", cleaned_text)
+        return cleaned_text

--- a/RP2040Home/configparsing/mqttconfig.py
+++ b/RP2040Home/configparsing/mqttconfig.py
@@ -1,4 +1,5 @@
 from .homeassistantdiscoveryconfig import HomeAssistantDiscoveryConfig
+from RP2040Home.configparsing.configparser import ConfigParser
 
 class MqttConfig:
     keys = [
@@ -23,4 +24,4 @@ class MqttConfig:
             if key == 'ha_discovery':
                 self.ha_discovery = HomeAssistantDiscoveryConfig(**value)
                 continue
-            setattr(self, key, value)
+            setattr(self, key, ConfigParser.clean_string(value))

--- a/RP2040Home/configparsing/output.py
+++ b/RP2040Home/configparsing/output.py
@@ -1,4 +1,4 @@
-from RP2040Home.configparsing.configparser import ConfigParser
+from RP2040Home.configparsing.inputsanitisation import InputSanitisation
 
 class Output:
     output_type: str
@@ -8,8 +8,19 @@ class Output:
     off_payload: str
 
     def __init__(self, output_type:str, name: str, pin: int, on_payload: str, off_payload: str):
-        self.output_type = ConfigParser.clean_string(output_type)
-        self.name = ConfigParser.clean_string(name)
-        self.pin = ConfigParser.clean_string(pin)
-        self.on_payload = ConfigParser.clean_string(on_payload)
-        self.off_payload = ConfigParser.clean_string(off_payload)
+        self.output_type = InputSanitisation().clean_string(output_type)
+        self.name = InputSanitisation().clean_string(name)
+        self.pin = pin
+        self.on_payload = InputSanitisation().clean_string(on_payload)
+        self.off_payload = InputSanitisation().clean_string(off_payload)
+
+    def __eq__(self, other):
+        if not isinstance(other, Output):
+            return False
+        return (
+            self.output_type == other.output_type and
+            self.name == other.name and
+            self.pin == other.pin and
+            self.on_payload == other.on_payload and
+            self.off_payload == other.off_payload
+        )

--- a/RP2040Home/configparsing/output.py
+++ b/RP2040Home/configparsing/output.py
@@ -1,3 +1,4 @@
+from RP2040Home.configparsing.configparser import ConfigParser
 
 class Output:
     output_type: str
@@ -7,8 +8,8 @@ class Output:
     off_payload: str
 
     def __init__(self, output_type:str, name: str, pin: int, on_payload: str, off_payload: str):
-        self.output_type = output_type
-        self.name = name
-        self.pin = pin
-        self.on_payload = on_payload
-        self.off_payload = off_payload
+        self.output_type = ConfigParser.clean_string(output_type)
+        self.name = ConfigParser.clean_string(name)
+        self.pin = ConfigParser.clean_string(pin)
+        self.on_payload = ConfigParser.clean_string(on_payload)
+        self.off_payload = ConfigParser.clean_string(off_payload)

--- a/RP2040Home/test/configparsing/inputsanitisation_test.py
+++ b/RP2040Home/test/configparsing/inputsanitisation_test.py
@@ -1,0 +1,23 @@
+import unittest
+from RP2040Home.configparsing.inputsanitisation import InputSanitisation
+
+class InputSanitisation_Test(unittest.TestCase):
+    def setUp(self):
+        self.input_sanitiser = InputSanitisation()                    
+    def test_clean_string(self):
+        dirty_string = "This is a string with spaces and forbidden characters~!@#"
+        expected_string = "This-is-a-string-with-spaces-and-forbidden-characters"
+        self.assertEqual(expected_string, self.input_sanitiser.clean_string(dirty_string))
+        
+    def test_clean_string_multiple_spaces(self):
+        dirty_string = "This is a string with multiple      spaces and forbidden characters~!@#"
+        expected_string = "This-is-a-string-with-multiple-spaces-and-forbidden-characters"
+        self.assertEqual(expected_string, self.input_sanitiser.clean_string(dirty_string))
+    
+    def test_clean_string_leading_characters(self):
+        dirty_string = "!@#%----This is a string with multiple      spaces and forbidden characters~!@#"
+        expected_string = "This-is-a-string-with-multiple-spaces-and-forbidden-characters"
+        self.assertEqual(expected_string, self.input_sanitiser.clean_string(dirty_string))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
[Home Assistant doesn't really like anything that doesn't fit the [a-zA-Z0-9_-] pattern ](https://www.home-assistant.io/integrations/mqtt/#discovery-messages)
So now for all the relevant inputs, it will clean up and remove any erroneous characters