### PR TITLE
10 minute timer to refresh connections & minor refactor

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,10 @@ from RP2040Home.RP2040Home import RP2040Home
 
 
 def main():
-    RP2040Home(ConfigParser().load("config.json")).connect_wlan().start_connection()
+    RP2040Home(
+        ConfigParser().load("config.json")
+        ).connect_wlan() \
+        .start_connection() \
+        .subscribe()
 
 main()


### PR DESCRIPTION
This PR addresses #7 and #16 - on a 10 minute loop, we push a new message to home assistant and check that there's a valid wifi connection.

Since the discovery, command and status topics don't overlap, there's no issue of refreshing discovery interrupting a command.